### PR TITLE
fix: validate boolean schemas correctly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,26 @@
+### Go template
+# If you prefer the allow list template instead of the deny list, see community template:
+# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
+#
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out
+
+# Dependency directories (remove the comment below to include it)
+# vendor/
+
+# Go workspace file
+go.work
+
+*.iml
+.idea/
+

--- a/errors.go
+++ b/errors.go
@@ -14,7 +14,7 @@ func addError(err, errs error) error {
 		return err
 	}
 
-	return fmt.Errorf("%w\n%w", errs, err.Error())
+	return fmt.Errorf("%w\n%w", errs, err)
 }
 
 type validationError struct {
@@ -27,7 +27,7 @@ func (e *validationError) addToPath(segment string) {
 }
 
 func (e *validationError) Error() string {
-	pathParts := append([]string{"@"}, e.originPath...)
+	pathParts := append([]string{"$"}, e.originPath...)
 	return fmt.Sprintf("%v at %v", e.err, strings.Join(pathParts, "."))
 }
 

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,57 @@
+package jsonschema
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+)
+
+func addError(err, errs error) error {
+	if err == nil {
+		return errs
+	}
+	if errs == nil {
+		return err
+	}
+
+	return fmt.Errorf("%w\n%w", errs, err.Error())
+}
+
+type validationError struct {
+	err        error
+	originPath []string
+}
+
+func (e *validationError) addToPath(segment string) {
+	e.originPath = append([]string{segment}, e.originPath...)
+}
+
+func (e *validationError) Error() string {
+	pathParts := append([]string{"@"}, e.originPath...)
+	return fmt.Sprintf("%v at %v", e.err, strings.Join(pathParts, "."))
+}
+
+func (e *validationError) Unwrap() error {
+	return e.err
+}
+
+func addOriginPath(e error, name string) error {
+	if e == nil {
+		return nil
+	}
+	var ve *validationError
+	if errors.As(e, &ve) {
+		ve.addToPath(name)
+		return e
+	} else {
+		ve = &validationError{
+			err: e,
+		}
+		ve.addToPath(name)
+		return ve
+	}
+}
+
+func addOriginIndex(e error, idx int) error {
+	return addOriginPath(e, fmt.Sprintf("%v", idx))
+}

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,5 @@ require (
 	github.com/buger/jsonparser v1.1.1
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/xeipuuv/gojsonschema v1.2.0
-	golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d
+	golang.org/x/net v0.0.0-20210813154108-3a7c47852f19
 )

--- a/go.sum
+++ b/go.sum
@@ -16,6 +16,8 @@ github.com/xeipuuv/gojsonschema v1.2.0 h1:LhYJRs+L4fBtjZUfuSZIKGeVu0QRy8e5Xi7D17
 github.com/xeipuuv/gojsonschema v1.2.0/go.mod h1:anYRn/JVcOK2ZgGU+IjEV4nwlhoK5sQluxsYJ78Id3Y=
 golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d h1:20cMwl2fHAzkJMEA+8J4JgqBQcQGzbisXo31MIeenXI=
 golang.org/x/net v0.0.0-20210805182204-aaa1db679c0d/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
+golang.org/x/net v0.0.0-20210813154108-3a7c47852f19 h1:pzN0Wral37kJTTFXiLhleLL2Cz5QU5mP+pLgFwjUp30=
+golang.org/x/net v0.0.0-20210813154108-3a7c47852f19/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210423082822-04245dca01da/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=

--- a/helpers.go
+++ b/helpers.go
@@ -2,7 +2,6 @@ package jsonschema
 
 import (
 	"bytes"
-	"fmt"
 	"log"
 	"math/big"
 	"strings"
@@ -53,17 +52,6 @@ var regexpControlChars = map[string]string{
 	`\c]`: `\01D`,
 	`\c^`: `\01E`,
 	`\c_`: `\01F`,
-}
-
-func addError(err, errs error) error {
-	if err == nil {
-		return errs
-	}
-	if errs == nil {
-		return err
-	}
-
-	return fmt.Errorf("%w\n%s", errs, err.Error())
 }
 
 func convertRegexp(re string) string {

--- a/schema_refs_test.go
+++ b/schema_refs_test.go
@@ -10,7 +10,7 @@ func TestAddSchema(t *testing.T) {
 	var testRefSchemaSubitem = `{"$id":"http://example.com/schemas/subitem","properties":{"id":{"type":"number"},"label":{"type":"string"}}}`
 	var testDoc = `{"id":123,"item":{"id":321,"label":"item","subitem1":{"id":789,"label":"subitem1"},"subitem2":{"id":987,"label":"subitem2"}}}`
 	var testDocInvalid = `{"id":123,"item":{"id":321,"label":"item","subitem1":{"id":789,"label":"subitem1"},"subitem2":{"id":"987","label":"subitem2"}}}`
-	var expectedError = `value "987" is of type string, but should be of type: number at @.item.subitem2.id`
+	var expectedError = `value "987" is of type string, but should be of type: number at $.item.subitem2.id`
 
 	schema, err := NewFromString(testSchema)
 	if err != nil {

--- a/schema_refs_test.go
+++ b/schema_refs_test.go
@@ -10,7 +10,7 @@ func TestAddSchema(t *testing.T) {
 	var testRefSchemaSubitem = `{"$id":"http://example.com/schemas/subitem","properties":{"id":{"type":"number"},"label":{"type":"string"}}}`
 	var testDoc = `{"id":123,"item":{"id":321,"label":"item","subitem1":{"id":789,"label":"subitem1"},"subitem2":{"id":987,"label":"subitem2"}}}`
 	var testDocInvalid = `{"id":123,"item":{"id":321,"label":"item","subitem1":{"id":789,"label":"subitem1"},"subitem2":{"id":"987","label":"subitem2"}}}`
-	var expectedError = `value "987" is of type string, but should be of type: number`
+	var expectedError = `value "987" is of type string, but should be of type: number at @.item.subitem2.id`
 
 	schema, err := NewFromString(testSchema)
 	if err != nil {
@@ -42,7 +42,7 @@ func TestAddSchema(t *testing.T) {
 
 	valid, err = schema.Validate([]byte(testDocInvalid))
 	if err == nil || err.Error() != expectedError {
-		t.Fatalf(`unexpected empty error, expected: %s`, expectedError)
+		t.Fatalf(`unexpected error %v, expected: %s`, err, expectedError)
 	} else if valid {
 		t.Fatal(`expected document to be invalid`)
 	}

--- a/testdata/draft2019-09/boolean_schema.json
+++ b/testdata/draft2019-09/boolean_schema.json
@@ -14,6 +14,11 @@
                 "valid": true
             },
             {
+                "description": "empty string is valid",
+                "data": "",
+                "valid": true
+            },
+            {
                 "description": "boolean true is valid",
                 "data": true,
                 "valid": true
@@ -61,6 +66,11 @@
             },
             {
                 "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "empty string is invalid",
                 "data": "foo",
                 "valid": false
             },

--- a/testdata/draft2019-09/ref.json
+++ b/testdata/draft2019-09/ref.json
@@ -34,14 +34,14 @@
         "description": "relative pointer ref to object",
         "schema": {
             "properties": {
-                "foo": {"type": "integer"},
+                "foo": {"type": "string"},
                 "bar": {"$ref": "#/properties/foo"}
             }
         },
         "tests": [
             {
                 "description": "match",
-                "data": {"bar": 3},
+                "data": {"bar": "bu\\z"},
                 "valid": true
             },
             {

--- a/testdata/draft2020-12/boolean_schema.json
+++ b/testdata/draft2020-12/boolean_schema.json
@@ -14,6 +14,11 @@
                 "valid": true
             },
             {
+                "description": "empty string is valid",
+                "data": "",
+                "valid": true
+            },
+            {
                 "description": "boolean true is valid",
                 "data": true,
                 "valid": true
@@ -61,6 +66,11 @@
             },
             {
                 "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "empty string is invalid",
                 "data": "foo",
                 "valid": false
             },

--- a/testdata/draft2020-12/ref.json
+++ b/testdata/draft2020-12/ref.json
@@ -34,14 +34,14 @@
         "description": "relative pointer ref to object",
         "schema": {
             "properties": {
-                "foo": {"type": "integer"},
+                "foo": {"type": "string"},
                 "bar": {"$ref": "#/properties/foo"}
             }
         },
         "tests": [
             {
                 "description": "match",
-                "data": {"bar": 3},
+                "data": {"bar": "bu\\z"},
                 "valid": true
             },
             {

--- a/testdata/draft4/ref.json
+++ b/testdata/draft4/ref.json
@@ -34,14 +34,14 @@
         "description": "relative pointer ref to object",
         "schema": {
             "properties": {
-                "foo": {"type": "integer"},
+                "foo": {"type": "string"},
                 "bar": {"$ref": "#/properties/foo"}
             }
         },
         "tests": [
             {
                 "description": "match",
-                "data": {"bar": 3},
+                "data": {"bar": "bu\\z"},
                 "valid": true
             },
             {

--- a/testdata/draft6/boolean_schema.json
+++ b/testdata/draft6/boolean_schema.json
@@ -14,6 +14,11 @@
                 "valid": true
             },
             {
+                "description": "empty string is valid",
+                "data": "",
+                "valid": true
+            },
+            {
                 "description": "boolean true is valid",
                 "data": true,
                 "valid": true
@@ -61,6 +66,11 @@
             },
             {
                 "description": "string is invalid",
+                "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "empty string is invalid",
                 "data": "foo",
                 "valid": false
             },

--- a/testdata/draft6/ref.json
+++ b/testdata/draft6/ref.json
@@ -34,14 +34,14 @@
         "description": "relative pointer ref to object",
         "schema": {
             "properties": {
-                "foo": {"type": "integer"},
+                "foo": {"type": "string"},
                 "bar": {"$ref": "#/properties/foo"}
             }
         },
         "tests": [
             {
                 "description": "match",
-                "data": {"bar": 3},
+                "data": {"bar": "bu\\z"},
                 "valid": true
             },
             {

--- a/testdata/draft7/boolean_schema.json
+++ b/testdata/draft7/boolean_schema.json
@@ -14,6 +14,11 @@
                 "valid": true
             },
             {
+                "description": "empty string is valid",
+                "data": "",
+                "valid": true
+            },
+            {
                 "description": "boolean true is valid",
                 "data": true,
                 "valid": true
@@ -62,6 +67,11 @@
             {
                 "description": "string is invalid",
                 "data": "foo",
+                "valid": false
+            },
+            {
+                "description": "empty string is invalid",
+                "data": "",
                 "valid": false
             },
             {

--- a/testdata/draft7/ref.json
+++ b/testdata/draft7/ref.json
@@ -34,14 +34,14 @@
         "description": "relative pointer ref to object",
         "schema": {
             "properties": {
-                "foo": {"type": "integer"},
+                "foo": {"type": "string"},
                 "bar": {"$ref": "#/properties/foo"}
             }
         },
         "tests": [
             {
                 "description": "match",
-                "data": {"bar": 3},
+                "data": {"bar": "bu\\z"},
                 "valid": true
             },
             {

--- a/validate.go
+++ b/validate.go
@@ -33,6 +33,9 @@ func (s *Schema) Validate(jsonDoc []byte) (bool, error) {
 	if s == nil {
 		return false, errors.New("invalid schema")
 	}
+	if len(jsonDoc) == 0 {
+		return false, errors.New("empty document is not valid JSON")
+	}
 
 	// Ensure that datectors work (though it slows things down a bit)
 	jsonDoc = bytes.Trim(jsonDoc, " \r\n")

--- a/validate_test.go
+++ b/validate_test.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/flowstack/go-jsonschema/testtools"
+	"github.com/stretchr/testify/assert"
 	"github.com/xeipuuv/gojsonschema"
 )
 
@@ -104,11 +105,7 @@ func TestValidateEmptyDocWithSchema(t *testing.T) {
 	}
 
 	_, err = schema.Validate([]byte(""))
-	if err == nil {
-		t.Fatal(`expected empty err, expected: empty document does not validate against the schema`)
-	} else if err.Error() != `empty document is not valid against any other schemas than "false"` {
-		t.Fatalf(`expected error to be:\nempty document is not valid against any other schemas than "false"\n, got:\n%s`, err.Error())
-	}
+	assert.Error(t, err) // empty document is not valid JSON and therefore cannot be valid against any schema
 }
 
 func TestValidateSchemaWithWrongSchema(t *testing.T) {
@@ -117,36 +114,6 @@ func TestValidateSchemaWithWrongSchema(t *testing.T) {
 		t.Fatal(`expected err`)
 	} else if err.Error() != "invalid schema" {
 		t.Fatalf("expected error to be:\ninvalid schema\n, got:\n%s", err.Error())
-	}
-}
-
-// TODO: verify that this is the wanted outcome
-func TestValidateEmptyDocWithFalseSchema(t *testing.T) {
-	schema, err := NewFromString("false")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	valid, err := schema.Validate([]byte(""))
-	if err != nil {
-		t.Fatalf("expected error to be empty, got:\n%s", err.Error())
-	} else if !valid {
-		t.Fatal(`expected document to be valid`)
-	}
-}
-
-// TODO: verify that this is the wanted outcome
-func TestValidateValueWithTrueSchema(t *testing.T) {
-	schema, err := NewFromString("true")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	valid, err := schema.Validate([]byte("1"))
-	if err != nil {
-		t.Fatalf(`expected error to be empty, got: %s`, err.Error())
-	} else if !valid {
-		t.Fatal(`expected document to be valid`)
 	}
 }
 

--- a/validators.go
+++ b/validators.go
@@ -45,26 +45,10 @@ func validate(value []byte, vt ValueType, schema *Schema) error {
 }
 
 func validateValue(value []byte, vt ValueType, schema *Schema) error {
-	// If the we have an empty value and the schema is not boolean (false), then the doc is invalid
-	// if len(value) == 0 && schema.boolean != nil && !*schema.boolean {
-	if len(value) == 0 && schema.IsEmpty() {
-		return errors.New(`empty document is not valid against any other schemas than "false"`)
-	}
 	return nil
 }
 
 func validateBooleanSchema(value []byte, vt ValueType, schema *Schema) error {
-	// Start by checking for empty JSON value
-	if len(value) == 0 {
-		// If we have an empty value and a boolean false schema then the value is valid
-		if !*schema.boolean {
-			return nil
-		}
-		// If we do not have a boolean false schema, but have an empty value, then the doc is invalid
-		return errors.New("empty document does not validate against the schema")
-	}
-
-	// If we have a value and a boolean true schema then the value is valid
 	if *schema.boolean {
 		return nil
 	}

--- a/validators.go
+++ b/validators.go
@@ -30,14 +30,6 @@ func validate(value []byte, vt ValueType, schema *Schema) error {
 		return errors.New("no schema supplied")
 	}
 
-	if vt == String {
-		value, err = jsonparser.Unescape(value, nil)
-		if err != nil {
-			log.Println(err)
-			return err
-		}
-	}
-
 	if len(schema.validators) == 0 {
 		return errors.New("no validators found - at least 1 was expected")
 	}
@@ -282,6 +274,11 @@ func validatePattern(value []byte, vt ValueType, schema *Schema) error {
 	if vt != String {
 		return nil
 	}
+	value, err := jsonparser.Unescape(value, nil)
+	if err != nil {
+		log.Println(err)
+		return err
+	}
 
 	if !schema.patternRegexp.Match(value) {
 		return errors.New("value did not match pattern")
@@ -291,8 +288,9 @@ func validatePattern(value []byte, vt ValueType, schema *Schema) error {
 }
 
 // TODO: It might be necessary and / or better to split ValidateProperties into it's
-// 	     original multiple ValidateXxx methods, so that they do not depend on a
-//       properties object to exist.
+//
+//		     original multiple ValidateXxx methods, so that they do not depend on a
+//	      properties object to exist.
 func validatePropertyNames(value []byte, vt ValueType, schema *Schema) error {
 	// Ignore anything other than Objects (probably an Array)
 	if vt != Object {
@@ -565,6 +563,11 @@ func validateMaxLength(value []byte, vt ValueType, schema *Schema) error {
 	if vt != String {
 		return nil
 	}
+	value, err := jsonparser.Unescape(value, nil)
+	if err != nil {
+		log.Println(err)
+		return err
+	}
 	if utf8.RuneCount(value) > int(*schema.MaxLength) {
 		return fmt.Errorf("length of value is more than %d", *schema.MaxLength)
 	}
@@ -575,6 +578,11 @@ func validateMinLength(value []byte, vt ValueType, schema *Schema) error {
 	// Ignore anything but strings
 	if vt != String {
 		return nil
+	}
+	value, err := jsonparser.Unescape(value, nil)
+	if err != nil {
+		log.Println(err)
+		return err
 	}
 	if utf8.RuneCount(value) < int(*schema.MinLength) {
 		return fmt.Errorf("length of value is less than %d", *schema.MinLength)
@@ -617,6 +625,11 @@ func validateConst(value []byte, vt ValueType, schema *Schema) error {
 		value = sortObject(value)
 
 	} else if vt == String {
+		value, err := jsonparser.Unescape(value, nil)
+		if err != nil {
+			log.Println(err)
+			return err
+		}
 		if schema.Const.String != nil && *schema.Const.String == string(value) {
 			return nil
 		}
@@ -658,6 +671,11 @@ func validateFormat(value []byte, vt ValueType, schema *Schema) error {
 	// Ignore anything that is not a string
 	if vt != String {
 		return nil
+	}
+	value, err := jsonparser.Unescape(value, nil)
+	if err != nil {
+		log.Println(err)
+		return err
 	}
 
 	// Parse takes a layout string, which defines the format by showing how the reference time,


### PR DESCRIPTION
Fixes the incorrect validation of boolean schemas. According to the spec from [draft 6](https://json-schema.org/draft-06/draft-wright-json-schema-01#rfc.section.4.4) and on, schema "true" always passes validation, while schema "false" always fails, independently of the length of the document.

Note that this PR builds on #4.